### PR TITLE
Fix NPE from posted chatmessages

### DIFF
--- a/src/main/java/com/tsbreuer/multilines/MultiLinesPlugin.java
+++ b/src/main/java/com/tsbreuer/multilines/MultiLinesPlugin.java
@@ -173,13 +173,21 @@ public class MultiLinesPlugin extends Plugin {
 			arrayListToUpdate.addAll(tempArray);
 			UpdateSpearRanges(); // Once we're done, update Spear Ranges
 			//log.debug("Multi Areas Updated");
-			clientThread.invokeLater(() -> {
-				client.addChatMessage(ChatMessageType.GAMEMESSAGE, "MultiLines", "Lastest Multi Lines Loaded from github", null);
-			});
+			if (client.getGameState() == GameState.LOGGED_IN)
+			{
+				clientThread.invokeLater(() -> {
+					client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "Lastest Multi Lines Loaded from github", null);
+				});
+			}
 		} catch (IOException | InterruptedException | IllegalStateException e) {
-			clientThread.invokeLater(() -> {
-				client.addChatMessage(ChatMessageType.GAMEMESSAGE, "MultiLines", "Error Loading Multi Lines from GitHub", null);
-			});
+			if (client.getGameState() == GameState.LOGGED_IN)
+			{
+				clientThread.invokeLater(() -> {
+					log.info("Error fetching data: {}", e.getMessage());
+
+					client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "Error Loading Multi Lines from GitHub", null);
+				});
+			}
 
 			//log.debug("Error Loading Multi Tiles from Github");;
 		}

--- a/src/main/java/com/tsbreuer/multilines/MultiLinesPlugin.java
+++ b/src/main/java/com/tsbreuer/multilines/MultiLinesPlugin.java
@@ -176,7 +176,7 @@ public class MultiLinesPlugin extends Plugin {
 			if (client.getGameState() == GameState.LOGGED_IN)
 			{
 				clientThread.invokeLater(() -> {
-					client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "Lastest Multi Lines Loaded from github", null);
+					client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "Latest Multi Lines Loaded from github", null);
 				});
 			}
 		} catch (IOException | InterruptedException | IllegalStateException e) {


### PR DESCRIPTION
This PR is intended to fix NPE from occurring when fetching the data; prevent posting the message when the user is not logged in and omit sender name (it is redundant for `ChatMessageType.GAMEMESSAGE`). The NPE occurrs in the [`LootTrackerPlugin`](https://github.com/runelite/runelite/blob/master/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java#L1020) as the plugin attempts to retrieve the player location when one does not exist, as messages are only expected when a player is logged in. Adding a clause to only post when the player is logged in fixes this issue, and eliminates reduntant messages which don't do anything to the user anyway.

Stacktrace of the error:
```log
2024-07-16 21:37:15 KST [Client] WARN  n.runelite.client.eventbus.EventBus - Uncaught exception in event subscriber
java.lang.NullPointerException: null
	at net.runelite.client.plugins.loottracker.LootTrackerPlugin.onChatMessage(LootTrackerPlugin.java:1020)
	at net.runelite.client.eventbus.EventBus$Subscriber.invoke(EventBus.java:70)
	at net.runelite.client.eventbus.EventBus.post(EventBus.java:223)
	at net.runelite.client.callback.Hooks.post(Hooks.java:202)
	at client.addChatMessage(client.java:26589)
	at client.addChatMessage(client.java:36246)
	at com.tsbreuer.multilines.MultiLinesPlugin.lambda$UpdateMultiLines$3(MultiLinesPlugin.java:178)
	at net.runelite.client.callback.ClientThread.lambda$invokeLater$1(ClientThread.java:80)
	at net.runelite.client.callback.ClientThread.invokeList(ClientThread.java:119)
	at net.runelite.client.callback.ClientThread.invoke(ClientThread.java:101)
	at net.runelite.client.callback.Hooks.tick(Hooks.java:226)
	at client.fy(client.java:6507)
	at client.bw(client.java)
	at bs.ar(bs.java:388)
	at bs.jg(bs.java)
	at bs.run(bs.java:7916)
	at java.base/java.lang.Thread.run(Thread.java:834)
```
	