### PR TITLE
Fix lines not updating on plugin disable-enable

### DIFF
--- a/src/main/java/com/tsbreuer/multilines/MultiLinesPlugin.java
+++ b/src/main/java/com/tsbreuer/multilines/MultiLinesPlugin.java
@@ -112,9 +112,13 @@ public class MultiLinesPlugin extends Plugin {
 	public void startUp() {
 		overlayManager.add(overlay);
 		config.setWarning("Warning, this plugin does not include Wilderness Multi Areas. Please use Wilderness Lines for that.");
-		executor.execute(() ->
-				UpdateMultiLines(Multi_MULTI_AREAS)
-		);
+		executor.execute(() -> UpdateMultiLines(Multi_MULTI_AREAS));
+
+		if (client.getGameState() == GameState.LOGGED_IN)
+		{
+			executor.execute(() -> updateLinesToDisplayNormal(MULTI_AREA));
+			executor.execute(() -> updateLinesToDisplaySpear(SPEAR_MULTI_AREA));
+		}
 	}
 
 	@Override


### PR DESCRIPTION
If the plugin has paths in memory, disabling, moving to another location and enabling the plugin will render the same paths, since the paths are not updated on startup, only on `GamestateChanged`. This PR intends to fix this behaviour so that the paths are updated when the plugin is started.